### PR TITLE
Update footer.html.twig

### DIFF
--- a/templates/_includes/global/footer.html.twig
+++ b/templates/_includes/global/footer.html.twig
@@ -17,7 +17,7 @@
 					{% if umd_terp_footer_logo_svg %}
 						{{ umd_terp_footer_logo_svg|raw }}
 					{% else %}
-						<img src="{{ footer_logo_path }}" alt="{{ site_name }} logo">
+						<img src="{{ footer_logo_path }}" alt="{{ site_name }} footer logo">
 					{% endif %}
 				</div>
 				<div class="site-footer-address">


### PR DESCRIPTION
The alternative name throws an alert about being too close a name to a nearby image.
Example here: https://wave.webaim.org/report#/https://studentconduct.umd.edu/covid-updates/covid-19-expectations

It isn't consistent. I think it's based on body content? Just a suggestion to make it explicit here.